### PR TITLE
PM as execute_process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ endforeach()
 zephyr_compile_definitions(
   KERNEL
   __ZEPHYR__=1
+  USE_PARTITION_MANAGER=$<TARGET_PROPERTY:gen_expr,PARTITION_MANAGER_ENABLED>
 )
 
 # @Intent: Set compiler flags to enable buffer overflow checks in libc functions
@@ -461,23 +462,6 @@ function(construct_add_custom_command_for_linker_pass linker_output_name output_
     set(linker_pass_define -DLINKER_PASS2)
   elseif (${linker_output_name} MATCHES "^linker_app_smem_unaligned$")
     set(linker_pass_define -DLINKER_APP_SMEM_UNALIGNED)
-  elseif (${linker_output_name} MATCHES "^linker$")
-    if(EXISTS ${APPLICATION_SOURCE_DIR}/pm.yml)
-      zephyr_compile_definitions(USE_PARTITION_MANAGER)
-      # Set a global property, so that all images (including the root image),
-      # get the variable set.
-      set_property(GLOBAL PROPERTY PROPERTY_PARTITION_MANAGER_TARGET
-        PARTITION_MANAGER_TARGET)
-      # Duplicates are removed before this list is used.
-      set_property(GLOBAL APPEND PROPERTY
-        ${IMAGE}PROPERTY_LINKER_SCRIPT_DEFINES
-        -DUSE_PARTITION_MANAGER)
-      # Below is needed to ensure that the origin app is placed correctly.
-      set_property(GLOBAL APPEND PROPERTY
-        PROPERTY_LINKER_SCRIPT_DEFINES
-        -DUSE_PARTITION_MANAGER)
-      add_dependencies(${OFFSETS_LIB} PARTITION_MANAGER_TARGET)
-    endif()
   else()
     set(linker_pass_define "")
   endif()
@@ -501,15 +485,16 @@ function(construct_add_custom_command_for_linker_pass linker_output_name output_
   zephyr_get_include_directories_for_lang(C current_includes)
   file(RELATIVE_PATH base_name "${CMAKE_BINARY_DIR}" "${PROJECT_BINARY_DIR}")
   get_property(current_defines GLOBAL PROPERTY ${IMAGE}PROPERTY_LINKER_SCRIPT_DEFINES)
-  get_property(partition_manager_target GLOBAL PROPERTY
-    PROPERTY_PARTITION_MANAGER_TARGET)
-  list(REMOVE_DUPLICATES current_includes)
+
+  # Set flag indicating if partition manager is active.
+  list(APPEND
+    current_defines
+    -DUSE_PARTITION_MANAGER=$<TARGET_PROPERTY:gen_expr,PARTITION_MANAGER_ENABLED>)
 
   set(${output_variable}
     OUTPUT ${linker_cmd_file_name}
     DEPENDS
     ${LINKER_SCRIPT}
-    ${partition_manager_target}
     ${extra_dependencies}
     # NB: 'linker_script_dep' will use a keyword that ends 'DEPENDS'
     ${linker_script_dep}

--- a/include/arch/arm/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/cortex_m/scripts/linker.ld
@@ -39,7 +39,7 @@
   #define SKIP_TO_KINETIS_FLASH_CONFIG
 #endif
 
-#ifdef USE_PARTITION_MANAGER
+#if USE_PARTITION_MANAGER
 #include <pm_config.h>
 #define ROM_ADDR PM_ADDRESS
 #define ROM_SIZE PM_SIZE

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -13,7 +13,7 @@
  * DeviceTree information when we are using the Partition Manager.
  */
 
-#ifdef USE_PARTITION_MANAGER
+#if USE_PARTITION_MANAGER
 #include <pm_config.h>
 #include <misc/util.h>
 


### PR DESCRIPTION
Pros:
 - Can use generator expressions for PM_ values

Cons:
- No preprocessing of pm.yml, we need the same scheme as kconfig and dts for selecting board specific configs (ie pm_nrf52840_pca10056.yml).

TODO add more pros and cons