### PR TITLE
cmake: Deprecate gen_expr in favour of partition_manager

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -244,10 +244,6 @@ if(FIRST_BOILERPLATE_EXECUTION)
   endif()
   message(STATUS "Cache files will be written to: ${USER_CACHE_DIR}")
 
-  # Add target used for generator expressions.
-  # This is needed in order to express arbitrary variable values as a 
-  # generator expression.
-  add_custom_target(gen_expr)
 else() # NOT FIRST_BOILERPLATE_EXECUTION
 
   # Have the child image select the same BOARD that was selected by

--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -11,6 +11,9 @@ if(FIRST_BOILERPLATE_EXECUTION)
     PARTITION_MANAGER_CONFIG_FILES
     )
   if(partition_manager_config_files)
+    # Partition manager is enabled because we have populated config
+    # files.
+
     execute_process(
       COMMAND
       ${PYTHON_EXECUTABLE}
@@ -22,18 +25,17 @@ if(FIRST_BOILERPLATE_EXECUTION)
     # Make Partition Manager configuration available in CMake
     import_kconfig(PM_ ${PROJECT_BINARY_DIR}/include/generated/pm.config)
 
+    # Create a dummy target that we can add properties to for
+    # extraction in generator expressions.
+    add_custom_target(partition_manager)
     set_property(
-      TARGET gen_expr
+      TARGET partition_manager
       PROPERTY MCUBOOT_SLOT_SIZE
       ${PM_MCUBOOT_PARTITIONS_PRIMARY_SIZE})
     set_property(
-      TARGET gen_expr
+      TARGET partition_manager
       PROPERTY MCUBOOT_HEADER_SIZE
       ${PM_MCUBOOT_PAD_SIZE})
-    set_property(
-      TARGET gen_expr
-      PROPERTY PARTITION_MANAGER_ENABLED
-      1)
     if (PM_SPM_ADDRESS AND PM_MCUBOOT_ADDRESS)
       set(merged_to_sign_hex ${CMAKE_BINARY_DIR}/merged_to_sign.hex)
       add_custom_command(
@@ -50,19 +52,14 @@ if(FIRST_BOILERPLATE_EXECUTION)
         )
       add_custom_target(merged_to_sign_target DEPENDS ${merged_to_sign_hex})
       set_property(
-        TARGET gen_expr
+        TARGET partition_manager
         PROPERTY MCUBOOT_TO_SIGN
         ${merged_to_sign_hex})
       set_property(
-        TARGET gen_expr
+        TARGET partition_manager
         PROPERTY MCUBOOT_TO_SIGN_DEPENDS
         merged_to_sign_target
         )
     endif()
-  else()
-    set_property(
-      TARGET gen_expr
-      PROPERTY PARTITION_MANAGER_ENABLED
-      0)
   endif()
 endif()


### PR DESCRIPTION
Deprecate gen_expr in favour of partition_manager. We want to avoid
patching boilerplate.cmake more than necessary, this removes one line
from boilerplate.cmake.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>